### PR TITLE
Fix time zone setting reset after sleep/restart

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -247,8 +247,8 @@ const Azan = new Lang.Class({
     this._updateAutoLocation();
     this._opt_latitude = this._settings.get_double(PrefsKeys.LATITUDE);
     this._opt_longitude = this._settings.get_double(PrefsKeys.LONGITUDE);
-    this._opt_timeformat12 = this._settings.get_boolean(PrefsKeys.TIME_FORAMT_12);
-    this._opt_timezone = this._settings.get_double(PrefsKeys.TIMEZONE);
+    this._opt_timeformat12 = this._settings.get_boolean(PrefsKeys.TIME_FORMAT_12);
+    this._opt_timezone = this._settings.get_string(PrefsKeys.TIMEZONE);
     this._opt_concise_list = this._settings.get_string(PrefsKeys.CONCISE_LIST);
   },
   _bindSettings: function() {
@@ -273,7 +273,7 @@ const Azan = new Lang.Class({
 
         this._updateLabel();
     }));
-    this._settings.connect('changed::' + PrefsKeys.TIME_FORAMT_12, Lang.bind(this, function(settings, key) {
+    this._settings.connect('changed::' + PrefsKeys.TIME_FORMAT_12, Lang.bind(this, function(settings, key) {
         this._opt_timeformat12 = settings.get_boolean(key);
         this._updateLabel();
     }));

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -299,7 +299,7 @@ const AzanPrefsWidget = new GObject.Class({
 
         let display_page = new PagePrefsGrid();
 
-        this.time_format_12 = display_page.add_boolean('AM/PM time format', PrefsKeys.TIME_FORAMT_12);
+        this.time_format_12 = display_page.add_boolean('AM/PM time format', PrefsKeys.TIME_FORMAT_12);
 
         display_page.add_combo('Which times?', PrefsKeys.CONCISE_LIST, [
           {'title': 'All times', 'value': '0'},

--- a/src/prefs_keys.js
+++ b/src/prefs_keys.js
@@ -3,5 +3,5 @@ var CALCULATION_METHOD = 'calculation-method';
 var LATITUDE = 'latitude';
 var LONGITUDE = 'longitude';
 var TIMEZONE = 'timezone';
-var TIME_FORAMT_12 = 'time-format-12';
+var TIME_FORMAT_12 = 'time-format-12';
 var CONCISE_LIST = 'concise-list';


### PR DESCRIPTION
Fixes #7 . TIMEZONE data type was string, but the _loadSettings method was tying to get its value through get_double method, hence was not loading it.
Also, TIME_FORAMT_12 is corrected to TIME_FORMAT_12 in all files. This was just a spelling correction, nothing more.